### PR TITLE
Add prototype product video generation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Automated Product Video Generator
+
+This project explores an automated pipeline to create promotional videos from
+e-commerce product pages.
+
+## Components
+- **Web Scraping** – `scraper.py` collects product details and image URLs.
+- **Script Generation** – `script_generator.py` builds a marketing blurb.
+- **Text To Speech** – `tts.py` converts the script into spoken audio.
+- **Video Assembly** – `video_assembler.py` makes a simple slideshow video.
+
+The entry point `main.py` wires the components together. Run it with a product
+URL and an output filename:
+
+```bash
+python -m autoprom.main "https://example.com/product" output.mp4
+```
+
+Additional polishing and error handling are required for production use.

--- a/autoprom/main.py
+++ b/autoprom/main.py
@@ -1,0 +1,35 @@
+"""Automated product video generator pipeline."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .scraper import scrape_product
+from .script_generator import generate_script
+from .tts import synthesize_audio
+from .video_assembler import build_video
+
+
+def generate_video(url: str, output: str) -> None:
+    info = scrape_product(url)
+    script = generate_script(info)
+
+    output_path = Path(output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    audio_path = str(output_path.with_suffix('.mp3'))
+    synthesize_audio(script, audio_path)
+
+    images = info.get('images', [])[:5]
+    if not images:
+        raise RuntimeError('No images found on product page.')
+
+    build_video(images, audio_path, str(output_path))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate promotional product video from URL")
+    parser.add_argument("url", help="Product page URL")
+    parser.add_argument("output", help="Path to output MP4 file")
+    args = parser.parse_args()
+    generate_video(args.url, args.output)

--- a/autoprom/scraper.py
+++ b/autoprom/scraper.py
@@ -1,0 +1,37 @@
+"""Web scraping utilities for product pages."""
+from __future__ import annotations
+
+import requests
+from bs4 import BeautifulSoup
+from typing import Dict, List
+
+
+def scrape_product(url: str) -> Dict[str, any]:
+    """Scrape basic product info from an e-commerce page.
+
+    This function is intentionally simple. It retrieves the page and attempts
+    to extract the title, description and image URLs.  Different shops will
+    require custom scraping logic – this serves as a starting point.
+    """
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    title = soup.title.text.strip() if soup.title else "Product"
+
+    # Try to find meta description
+    desc_tag = soup.find("meta", attrs={"name": "description"})
+    description = desc_tag["content"].strip() if desc_tag and desc_tag.get("content") else ""
+
+    images: List[str] = []
+    for img in soup.find_all("img"):
+        src = img.get("src")
+        if src and src.startswith("http"):
+            images.append(src)
+
+    return {
+        "url": url,
+        "title": title,
+        "description": description,
+        "images": images,
+    }

--- a/autoprom/script_generator.py
+++ b/autoprom/script_generator.py
@@ -1,0 +1,17 @@
+"""Generate marketing scripts from product information."""
+from __future__ import annotations
+
+from typing import Dict
+
+
+def generate_script(info: Dict[str, any]) -> str:
+    """Return a simple marketing script for the given product info.
+
+    In production this would call an LLM; for now we use a trivial template.
+    """
+    title = info.get("title", "Amazing Product")
+    description = info.get("description", "")
+    script = f"Presenting {title}! {description}"
+    if not description:
+        script += " Don't miss out on this fantastic item."
+    return script

--- a/autoprom/tts.py
+++ b/autoprom/tts.py
@@ -1,0 +1,14 @@
+"""Text-to-speech utilities."""
+from __future__ import annotations
+
+from gtts import gTTS
+
+
+def synthesize_audio(text: str, path: str) -> str:
+    """Synthesize *text* to speech and save to *path*.
+
+    Returns the path to the created audio file.
+    """
+    tts = gTTS(text)
+    tts.save(path)
+    return path

--- a/autoprom/video_assembler.py
+++ b/autoprom/video_assembler.py
@@ -1,0 +1,15 @@
+"""Video assembly utilities."""
+from __future__ import annotations
+
+from typing import List
+from moviepy.editor import ImageClip, AudioFileClip, concatenate_videoclips
+
+
+def build_video(images: List[str], audio_path: str, output_path: str, duration_per_image: float = 2.0) -> str:
+    """Create a simple slideshow video from images with an audio track."""
+    clips = [ImageClip(img).set_duration(duration_per_image) for img in images]
+    video = concatenate_videoclips(clips, method="compose")
+    audio = AudioFileClip(audio_path)
+    video = video.set_audio(audio)
+    video.write_videofile(output_path, fps=24)
+    return output_path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+requests
+beautifulsoup4
+gTTS
+moviepy


### PR DESCRIPTION
## Summary
- add modular pipeline for scraping product info, generating marketing script, text-to-speech, and video assembly
- document project structure and usage
- ignore Python bytecode artifacts

## Testing
- `python -m py_compile autoprom/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a196d3e4d48322b799d699bf85751c